### PR TITLE
Add stackdb and werror flags

### DIFF
--- a/Haskintex.hs
+++ b/Haskintex.hs
@@ -302,28 +302,23 @@ memoreduce modName isMemo t ty f = do
       -- Sandbox recognition
       inSandbox <- lift $ doesDirectoryExist ".cabal-sandbox"
       r <- if inSandbox
-              then do
-                outputStr "Sandbox detected."
-                noSandbox <- nosandboxFlag <$> get
-                if noSandbox
-                  then do
-                    outputStr "Ignoring sandbox."
-                    runInterpreter int
-                  else do
-                    stackDb <- stackDbFlag <$> get
-                    if stackDb
-                      then do
-                        pkgdb <- lift $ readCreateProcess (P.proc "stack path" ["--local-pkg-db"]) ""
-                        outputStr $ "Using sandbox package db: " ++ pkgdb
-                        unsafeRunInterpreterWithArgs ["-package-db " ++ pkgdb] int
-                      else do
-                        sand <- lift $ getDirectoryContents ".cabal-sandbox"
-                        let pkgdbs = filter (isSuffixOf "packages.conf.d") sand
-                        case pkgdbs of
-                          pkgdb : _ -> do
-                            outputStr $ "Using sandbox package db: " ++ pkgdb
-                            unsafeRunInterpreterWithArgs ["-package-db .cabal-sandbox/" ++ pkgdb] int
-                          _ -> runInterpreter int
+              then do outputStr "Sandbox detected."
+                      noSandbox <- nosandboxFlag <$> get
+                      if noSandbox
+                        then do outputStr "Ignoring sandbox."
+                                runInterpreter int
+                        else do stackDb <- stackDbFlag <$> get
+                                if stackDb
+                                  then do pkgdb <- lift $ readCreateProcess (P.proc "stack path" ["--local-pkg-db"]) ""
+                                          outputStr $ "Using sandbox package db: " ++ pkgdb
+                                          unsafeRunInterpreterWithArgs ["-package-db " ++ pkgdb] int
+                                  else do sand <- lift $ getDirectoryContents ".cabal-sandbox"
+                                          let pkgdbs = filter (isSuffixOf "packages.conf.d") sand
+                                          case pkgdbs of
+                                            pkgdb : _ -> do
+                                              outputStr $ "Using sandbox package db: " ++ pkgdb
+                                              unsafeRunInterpreterWithArgs ["-package-db .cabal-sandbox/" ++ pkgdb] int
+                                            _ -> runInterpreter int
               else runInterpreter int
       case r of
         Left err -> do

--- a/Haskintex.hs
+++ b/Haskintex.hs
@@ -4,7 +4,8 @@
 module Haskintex (haskintex) where
 
 -- System
-import System.Process (readProcess)
+import System.Process (readProcess, readCreateProcess)
+import qualified System.Process as P (proc)
 import System.FilePath
 import System.Directory
 import System.IO (hFlush,stdout)
@@ -50,8 +51,6 @@ import Data.Binary.Get hiding (lookAhead)
 import Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy as LB
 import qualified Data.ByteString as SB
--- Shell
-import Shelly (shelly, bash)
 
 -- Syntax
 
@@ -314,9 +313,9 @@ memoreduce modName isMemo t ty f = do
                     stackDb <- stackDbFlag <$> get
                     if stackDb
                       then do
-                        pkgdb <- shelly $ bash "stack path" ["--local-pkg-db"]
-                        outputStr $ "Using sandbox package db: " ++ unpack pkgdb
-                        unsafeRunInterpreterWithArgs ["-package-db " ++ unpack pkgdb, "-package yaml"] int
+                        pkgdb <- lift $ readCreateProcess (P.proc "stack path" ["--local-pkg-db"]) ""
+                        outputStr $ "Using sandbox package db: " ++ pkgdb
+                        unsafeRunInterpreterWithArgs ["-package-db " ++ pkgdb] int
                       else do
                         sand <- lift $ getDirectoryContents ".cabal-sandbox"
                         let pkgdbs = filter (isSuffixOf "packages.conf.d") sand

--- a/Haskintex.hs
+++ b/Haskintex.hs
@@ -305,20 +305,20 @@ memoreduce modName isMemo t ty f = do
               then do outputStr "Sandbox detected."
                       noSandbox <- nosandboxFlag <$> get
                       if noSandbox
-                        then do outputStr "Ignoring sandbox."
-                                runInterpreter int
-                        else do stackDb <- stackDbFlag <$> get
-                                if stackDb
-                                  then do pkgdb <- lift $ readCreateProcess (P.proc "stack path" ["--local-pkg-db"]) ""
-                                          outputStr $ "Using sandbox package db: " ++ pkgdb
-                                          unsafeRunInterpreterWithArgs ["-package-db " ++ pkgdb] int
-                                  else do sand <- lift $ getDirectoryContents ".cabal-sandbox"
-                                          let pkgdbs = filter (isSuffixOf "packages.conf.d") sand
-                                          case pkgdbs of
-                                            pkgdb : _ -> do
-                                              outputStr $ "Using sandbox package db: " ++ pkgdb
-                                              unsafeRunInterpreterWithArgs ["-package-db .cabal-sandbox/" ++ pkgdb] int
-                                            _ -> runInterpreter int
+                         then do outputStr "Ignoring sandbox."
+                                 runInterpreter int
+                         else do stackDb <- stackDbFlag <$> get
+                                 if stackDb
+                                    then do pkgdb <- lift $ readCreateProcess (P.proc "stack path" ["--local-pkg-db"]) ""
+                                            outputStr $ "Using sandbox package db: " ++ pkgdb
+                                            unsafeRunInterpreterWithArgs ["-package-db " ++ pkgdb] int
+                                    else do sand <- lift $ getDirectoryContents ".cabal-sandbox"
+                                            let pkgdbs = filter (isSuffixOf "packages.conf.d") sand
+                                            case pkgdbs of
+                                              pkgdb : _ -> do
+                                                outputStr $ "Using sandbox package db: " ++ pkgdb
+                                                unsafeRunInterpreterWithArgs ["-package-db .cabal-sandbox/" ++ pkgdb] int
+                                              _ -> runInterpreter int
               else runInterpreter int
       case r of
         Left err -> do

--- a/haskintex.cabal
+++ b/haskintex.cabal
@@ -50,7 +50,7 @@ library
                , transformers >= 0.3.0.0
                , text >= 0.11.2.3 && < 2
                , bytestring >= 0.10.4
-               , directory >= 1.2.0 && < 1.3
+               , directory >= 1.2.0 && < 1.4
                , filepath >= 1.1.0 && < 1.5
                , process >= 1.2.0
                , HaTeX >= 3.9.0.0

--- a/haskintex.cabal
+++ b/haskintex.cabal
@@ -59,7 +59,6 @@ library
                , containers >= 0.5.5
                , binary >= 0.7.1
                , haskell-src-exts >= 1.18.2
-               , shelly >= 1.6
   exposed-modules: Haskintex
   other-modules: Paths_haskintex
   ghc-options: -Wall

--- a/haskintex.cabal
+++ b/haskintex.cabal
@@ -59,6 +59,7 @@ library
                , containers >= 0.5.5
                , binary >= 0.7.1
                , haskell-src-exts >= 1.18.2
+               , shelly >= 1.6
   exposed-modules: Haskintex
   other-modules: Paths_haskintex
   ghc-options: -Wall


### PR DESCRIPTION
Hi, I found that the following flags are useful but missing, so I added them in the PR:

*  `stackdb` - if set, haskintex would take package db from stack sandbox.

*  `werror` - if set, haskintex terminates when haskell evaluation is failed. That is need to detect rendering errors in other scripts that use `haskintex`

P.S. Thank you for the great tool!